### PR TITLE
商品一覧表示、編集、削除

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,9 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:show]
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, except: [:index, :new, :create, :category_search]
 
   def index
-    @items = Item.includes(:images).order('created_at DESC')
+    @items = Item.all
   end
 
   def new
@@ -36,6 +36,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    @parents = Category.all.order("id ASC").limit(13)
   end
 
   def update

--- a/app/views/items/_indexMain.html.haml
+++ b/app/views/items/_indexMain.html.haml
@@ -98,54 +98,29 @@
         = link_to "#" do
           新規投稿商品 
       .main__pickup__box__lists
-        .main__pickup__box__lists__list
-          = link_to "#" do
-            .main__pickup__box__lists__list__img
-              = image_tag "icon-04.png", class:"image", alt:"logo"
-            .main__pickup__box__lists__list__body
-              .main__pickup__box__lists__list__body__name
-                おかね
-              .main__pickup__box__lists__list__body__data
-                .main__pickup__box__lists__list__body__data__box
-                  .main__pickup__box__lists__list__body__data__money
-                    30000円
-                  .main__pickup__box__lists__list__body__data__like
-                    = icon('fa', 'star')
-                    0
-                .main__pickup__box__lists__list__body__data__tax
-                  (税込)
-        .main__pickup__box__lists__list
-          = link_to "#" do
-            .main__pickup__box__lists__list__img
-              = image_tag "icon-04.png", class:"image", alt:"logo"
-            .main__pickup__box__lists__list__body
-              .main__pickup__box__lists__list__body__name
-                現金
-              .main__pickup__box__lists__list__body__data
-                .main__pickup__box__lists__list__body__data__box
-                  .main__pickup__box__lists__list__body__data__money
-                    3000000円
-                  .main__pickup__box__lists__list__body__data__like
-                    = icon('fa', 'star')
-                    0
-                .main__pickup__box__lists__list__body__data__tax
-                  (税込)
-        .main__pickup__box__lists__list
-          = link_to "#" do
-            .main__pickup__box__lists__list__img
-              = image_tag "icon-04.png", class:"image", alt:"logo"
-            .main__pickup__box__lists__list__body
-              .main__pickup__box__lists__list__body__name
-                money
-              .main__pickup__box__lists__list__body__data
-                .main__pickup__box__lists__list__body__data__box
-                  .main__pickup__box__lists__list__body__data__money
-                    30000000円
-                  .main__pickup__box__lists__list__body__data__like
-                    = icon('fa', 'star')
-                    0
-                .main__pickup__box__lists__list__body__data__tax
-                  (税込)
+        - @items.last(3).each do |item|
+          .main__pickup__box__lists__list
+            = link_to "#" do
+              .main__pickup__box__lists__list__img
+                - item.images.first(1).each do |image|
+                  %img{:src => "#{image.src}", width: "220", height: '150'}
+              .main__pickup__box__lists__list__body
+                .main__pickup__box__lists__list__body__name
+                  = item.name
+                .main__pickup__box__lists__list__body__data
+                  .main__pickup__box__lists__list__body__data__box
+                    .main__pickup__box__lists__list__body__data__box__money
+                      %p
+                        ¥
+                        = item.price
+                    .main__pickup__box__lists__list__body__data__like
+                      = icon('fa', 'star')
+                      0
+                  .main__pickup__box__lists__list__body__data__tax
+                    (税込)
+                    - if current_user.id = item.id
+                      = link_to '編集', edit_item_path(item)
+                      = link_to '削除', item_path(item), method: :delete
   .main__pickup
     .main__pickup__head
       ピックアップブランド
@@ -154,51 +129,26 @@
         = link_to "#" do
           アーカイバ
       .main__pickup__box__lists
-        .main__pickup__box__lists__list
-          = link_to "#" do
-            .main__pickup__box__lists__list__img
-              = image_tag "icon-04.png", class:"image", alt:"logo"
-            .main__pickup__box__lists__list__body
-              .main__pickup__box__lists__list__body__name
-                おかね
-              .main__pickup__box__lists__list__body__data
-                .main__pickup__box__lists__list__body__data__box
-                  .main__pickup__box__lists__list__body__data__money
-                    30000円
-                  .main__pickup__box__lists__list__body__data__like
-                    = icon('fa', 'star')
-                    0
-                .main__pickup__box__lists__list__body__data__tax
-                  (税込)
-        .main__pickup__box__lists__list
-          = link_to "#" do
-            .main__pickup__box__lists__list__img
-              = image_tag "icon-04.png", class:"image", alt:"logo"
-            .main__pickup__box__lists__list__body
-              .main__pickup__box__lists__list__body__name
-                現金
-              .main__pickup__box__lists__list__body__data
-                .main__pickup__box__lists__list__body__data__box
-                  .main__pickup__box__lists__list__body__data__money
-                    3000000円
-                  .main__pickup__box__lists__list__body__data__like
-                    = icon('fa', 'star')
-                    0
-                .main__pickup__box__lists__list__body__data__tax
-                  (税込)
-        .main__pickup__box__lists__list
-          = link_to "#" do
-            .main__pickup__box__lists__list__img
-              = image_tag "icon-04.png", class:"image", alt:"logo"
-            .main__pickup__box__lists__list__body
-              .main__pickup__box__lists__list__body__name
-                money
-              .main__pickup__box__lists__list__body__data
-                .main__pickup__box__lists__list__body__data__box
-                  .main__pickup__box__lists__list__body__data__money
-                    30000000円
-                  .main__pickup__box__lists__list__body__data__like
-                    = icon('fa', 'star')
-                    0
-                .main__pickup__box__lists__list__body__data__tax
-                  (税込)
+        - @items.last(3).each do |item|
+          .main__pickup__box__lists__list
+            = link_to "#" do
+              .main__pickup__box__lists__list__img
+                - item.images.first(1).each do |image|
+                  %img{:src => "#{image.src}", width: "220", height: '150'}
+              .main__pickup__box__lists__list__body
+                .main__pickup__box__lists__list__body__name
+                  = item.name
+                .main__pickup__box__lists__list__body__data
+                  .main__pickup__box__lists__list__body__data__box
+                    .main__pickup__box__lists__list__body__data__money
+                      %p
+                        ¥
+                        = item.price
+                    .main__pickup__box__lists__list__body__data__like
+                      = icon('fa', 'star')
+                      0
+                  .main__pickup__box__lists__list__body__data__tax
+                    (税込)
+                    - if current_user.id = item.id
+                      = link_to '編集', edit_item_path(item)
+                      = link_to '削除', item_path(item), method: :delete

--- a/app/views/items/_indexMain.html.haml
+++ b/app/views/items/_indexMain.html.haml
@@ -103,7 +103,7 @@
             = link_to "#" do
               .main__pickup__box__lists__list__img
                 - item.images.first(1).each do |image|
-                  %img{:src => "#{image.src}", width: "220", height: '150'}
+                  = image_tag image.src.url, width: "220", height: '150'
               .main__pickup__box__lists__list__body
                 .main__pickup__box__lists__list__body__name
                   = item.name
@@ -134,7 +134,7 @@
             = link_to "#" do
               .main__pickup__box__lists__list__img
                 - item.images.first(1).each do |image|
-                  %img{:src => "#{image.src}", width: "220", height: '150'}
+                  = image_tag image.src.url, width: "220", height: '150'
               .main__pickup__box__lists__list__body
                 .main__pickup__box__lists__list__body__name
                   = item.name

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -33,10 +33,6 @@
                     .js-file_group{"data-index" => @item.images.count}
                       = file_field_tag :src, name: "image[images_attributes][#{@item.images.count}][src]", class: 'js-file'
                       .js-remove 削除
-                  -#   %br/
-                  -# ドラッグアンドドロップ
-                  -# %br
-                  -# またはクリックしてファイルをアップロード
         .input-error#item_image_error
         -# 商品名、商品の説明
         .sell-form-container.sell-container-all-padding.container-border-top
@@ -57,17 +53,15 @@
             商品の詳細
           .sell-container-right
             %p
-              -# = label :category_index, 'カテゴリー',class: 'sell-label'
+              = label :category, 'カテゴリー',class: 'sell-label'
               %span.form-box 必須
-              .select-wrap
-                .select-wrap__icon
-                  = icon('fas', 'angle-down')
-                -# = f.collection_select :category_id, @parents, :id, :name, {prompt: "選択してくだい"}, class: "select-wrap__select-box",id:"parent_category"
-                -#   %option{value: "0"}  選択してください
-            -# .category_wrapper
-            -#   .select-wrap.category_index_wrapper
-                -# = f.collection_select :category_id, @params, :id, :name, {prompt: "選択してください"}, id:"parent_category"
-              .input-error#item_category_index_id_error
+              %div.category-area
+                #parent-form-area
+                  .select-wrap
+                    = f.collection_select :category_id, @parents, :id, :name, {prompt: "選択してください"}, class: "select-wrap__select-box", id:"parent-form"
+                    %i.fas.fa-angle-down
+                #children-form-area
+                #grandchild-form-area
             %p.margin-2rem
               = label :brand, 'ブランド',class: 'sell-label'
               %span.form-box-option 任意
@@ -76,12 +70,9 @@
               = label :trading_status, '商品の状態',class: 'sell-label'
               %span.form-box 必須
               .select-wrap
-                .select-wrap__icon
-                  = icon('fas', 'angle-down')
-                = f.select :trading_status, TradingStatus.pluck(:status).unshift('選択してください'),{},{class: 'default-select select-wrap__sell-select-box'}
-                -# %select.select-wrap__select-box{name: "status", id: "status"}
-                -#   %option{value: "0"}  選択してください
-              -# = f.collection_select :trading_status_id, TradingStatus.group(:status).order(id: :asc), :id, :status, {prompt: "選択してください"},id:"newSelect"
+                = f.select :trading_status, TradingStatus.pluck(:status), {prompt: "選択してください"}, class: 'select-wrap__select-box'
+                %i.fas.fa-angle-down
+
         -# 配送について
         .sell-container-all-padding.container-border-top.flex
           .sell-container-left
@@ -94,47 +85,29 @@
               = label :postage_payer, '配送料の負担',class: 'sell-label'
               %span.form-box 必須
               .select-wrap
-                .select-wrap__icon
-                  = icon('fas', 'angle-down')
-                = f.select :postage_payer, PostagePayer.pluck(:payer).unshift('選択してください'),{},{class: 'default-select select-wrap__sell-select-box'}
-                -# = select :postage_payer, :name, Item.postage_payers.keys.to_a, include_blank: true
-                -# %select.select-wrap__select-box{name: "payer", id: "payer"}
-                -#   %option{value: "0"}  選択してください
-              -# = f.collection_select :postage_payer_id, PostagePayer.group(:payer).order(id: :asc), :id, :payer, {prompt: "選択してください"},id:"newSelect"
+                = f.select :postage_payer, PostagePayer.pluck(:payer), {prompt: "選択してください"}, {class: 'select-wrap__select-box'}
+                %i.fas.fa-angle-down
             .input-error#item_postage_payer_error
             %p.margin-2rem
               = label :postage_type, '配達方法',class: 'sell-label'
               %span.form-box 必須
               .select-wrap
-                .select-wrap__icon
-                  = icon('fas', 'angle-down')
-                = f.select :postage_type, PostageType.pluck(:type).unshift('選択してください'),{},{class: 'default-select select-wrap__sell-select-box'}
-              -#   %select.select-wrap__select-box{name: "", id: ""}
-              -#     %option{value: "0"}  選択してください
-              -# -# = f.collection_select :postage_type_id, PostageType.all, :name, :name, {prompt: "選択してください"}
+                = f.select :postage_type, PostageType.pluck(:type), {prompt: "選択してください"}, {class: 'select-wrap__select-box'}
+                %i.fas.fa-angle-down
             .input-error#item_postage_type_error
             %p.margin-2rem
               = label :shipping_area, '発送元の地域',class: 'sell-label'
               %span.form-box 必須
             .select-wrap
-              .select-wrap__icon
-                = icon('fas', 'angle-down')
-              = f.select :shipping_area, ShippingArea.pluck(:area).unshift('選択してください'),{},{class: 'default-select select-wrap__sell-select-box'}
-              -# %select.select-wrap__select-box{name: "area", id: "area"}
-              -#   %option{value: "0"}  選択してください
-            -# = f.collection_select :shipping_area_id, ShippingArea.group(:area).order(id: :asc), :id, :area, {prompt: "選択してください"},id:"newSelect"
+              = f.select :shipping_area, ShippingArea.pluck(:area), {prompt: "選択してください"}, {class: 'select-wrap__select-box'}
+              %i.fas.fa-angle-down
             .input-error#item_shipping_area_error
             %p.margin-2rem
               = label :shipping_date, '発送までの日数',class: 'sell-label'
               %span.form-box 必須
             .select-wrap
-              .select-wrap__icon
-                = icon('fas', 'angle-down')
-              = f.select :shipping_date, ShippingDate.pluck(:date).unshift('選択してください'),{},{class: 'default-select select-wrap__sell-select-box'}
-              -# = select :shipping_date, :name, Item.shipping_dates.keys.to_a
-              -# %select.select-wrap__select-box{name: "date", id: "date"}
-              -#   %option{value: "0"}  選択してください
-              -# = f.collection_select :shipping_date_id, ShippingDate.group(:date).order(id: :asc), :id, :date, {prompt: "選択してください"},id:"newSelect"
+              = f.select :shipping_date, ShippingDate.pluck(:date), {prompt: "選択してください"}, {class: 'select-wrap__select-box'}
+              %i.fas.fa-angle-down
             .input-error#item_shipping_date_error
         -# 販売価格
         .sell-container-all-padding.container-border-top.flex
@@ -160,13 +133,10 @@
                 %p
                   販売手数料(10%)
               .sell-container-right__price-fee__price
-                %p
-                  ー
             .sell-container-right__price-benefit
-              %p
+              %p.sell-container-right__price-benefit__text
                 販売利益
-              %p
-                ー
+              .sell-container-right__price-benefit__price
         -# 出品ボタン
         .sell-container-all-padding.container-border-top
           .sell-container-submit
@@ -192,4 +162,5 @@
               = link_to "加盟店規約"
               に同意したことになります。
   = render 'signin/footer'
--# コメントアウトの箇所はサーバーサイドの実装で使用予定
+= render partial: 'share/simple-header'
+

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,12 +1,3 @@
-.contents.row
-  - @items.each do |item|
-    %p= item.name
-    %span.name
-      = item.price
-    - item.images.each do |image|
-      = image_tag image.src.url
-    = link_to '編集', edit_item_path(item)
-    = link_to '削除', item_path(item), method: :delete
 = render "indexHeader"
 = render "indexMain"
 = render "indexBanner"

--- a/db/migrate/20200518134004_create_items.rb
+++ b/db/migrate/20200518134004_create_items.rb
@@ -7,7 +7,7 @@ class CreateItems < ActiveRecord::Migration[5.2]
       t.string     :brand
       t.string     :trading_status,    null: false
       t.string     :shipping_date,     null: false
-      t.integer    :size,             null: false
+      t.integer    :size
       t.string     :postage_payer,     null: false
       t.integer    :price,            null: false, foreign_key: true
       t.references :seller,           null: false, foreign_key: {to_table: :users}

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2020_05_18_183837) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["phone_number"], name: "index_addresses_on_phone_number", unique: true
     t.index ["user_id"], name: "index_addresses_on_user_id"
   end
 
@@ -60,7 +61,7 @@ ActiveRecord::Schema.define(version: 2020_05_18_183837) do
     t.string "brand"
     t.string "trading_status", null: false
     t.string "shipping_date", null: false
-    t.integer "size", null: false
+    t.integer "size"
     t.string "postage_payer", null: false
     t.integer "price", null: false
     t.bigint "seller_id", null: false


### PR DESCRIPTION
# What
商品の一覧表示、編集、削除
の実装を行いました。
一覧表示は最新の３つを表示するようにしました。
編集、削除は出品者のみに表示されるようにしました。
購入機能は未実装のため、売り切れ等の表示はしていません。

# Why
次の実装の購入確認、商品詳細ページ実装のためにデータを表示できるようにしました。
一覧表示の画面になります。
https://gyazo.com/f490f6397ac0f8104fe5c068c14f5ac3
編集を押すと保存してあるデータは初めから表示されています。
https://gyazo.com/105771f78a5e468333cc2635e91edf8e