### PR TITLE
add-turbolinks

### DIFF
--- a/app/views/items/_exhibition-item.html.haml
+++ b/app/views/items/_exhibition-item.html.haml
@@ -95,7 +95,7 @@
     .exhibition-item__buy-btn
       - if user_signed_in? && current_user.id == @item.seller_id
         = link_to "削除する", item_path(@item.id), method: :delete,class:"item-delete-btn"
-        = link_to "編集する", edit_item_path(@item.id),class:"item-edit-btn"
+        = link_to "編集する", edit_item_path(@item.id),class:"item-edit-btn", data: {"turbolinks" => false}
       - elsif @item.buyer_id.present? 
         = link_to "売り切れました",root_path,class:"disabled-button bold"
       - elsif user_signed_in?


### PR DESCRIPTION
#What
・商品詳細画面の編集からカテゴリ選択のJSが反応しない問題を修正
・turbolinksを追記
#Why
カテゴリ選択はlink_toにturbolinksを記述しているため、関係するlinkすべてに記述する必要がありました。